### PR TITLE
Changed 'it' to 'its' in Communications

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -12,7 +12,7 @@ Before continuing, If you haven't already, please review the [README](README.md)
 
 ## Communications ##  
 
-The FarmData2 community uses [Zulip](https://zulip.com/) as it communication platform. Zulip is a group chat application that blends the benefits of asynchronous threaded discussions (e.g. a forum) with live chat.
+The FarmData2 community uses [Zulip](https://zulip.com/) as its communication platform. Zulip is a group chat application that blends the benefits of asynchronous threaded discussions (e.g. a forum) with live chat.
 
 Connecting with the [FarmData2 community](https://farmdata2.zulipchat.com/) on Zulip provides a place to ask questions of the project managers and the broader developer community.
 


### PR DESCRIPTION
__Pull Request Description__

In the "ONBOARDING.md" file, there was a typo in the "Communications" section of the info. The incorrect line was "The FarmData2 community uses [Zulip](https://zulip.com/) as it communication platform." I had to change the 'it" from the sentence to "its" for it to be grammatically correct. 

Fixes #12 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
